### PR TITLE
Remove super from constructors for classes which inherit from Object

### DIFF
--- a/lib/tax_cloud/address.rb
+++ b/lib/tax_cloud/address.rb
@@ -8,7 +8,6 @@ module TaxCloud
       attrs.each do |sym, val|
         self.send "#{sym}=", val
       end
-      super
     end
 
     # Verify the address via TaxCloud

--- a/lib/tax_cloud/cart_item.rb
+++ b/lib/tax_cloud/cart_item.rb
@@ -16,7 +16,6 @@ module TaxCloud
       attrs.each do |sym, val|
         self.send "#{sym}=", val
       end
-      super
     end
 
     # Convert the object to a usable hash for SOAP requests


### PR DESCRIPTION
Remove super call from address and cart_item constructors, which were breaking on ruby 1.8.7 and 1.9.3
