### PR TITLE
Added TravisCI, fixed Ruby 1.8.7.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+rvm:
+  - 1.8.7
+  - 1.9.2
+  - 1.9.3
+  - ruby-head
+  - jruby
+  - rbx
+  - ree
+

--- a/README.rdoc
+++ b/README.rdoc
@@ -1,5 +1,7 @@
 = TaxCloud
 
+{<img src="https://travis-ci.org/drewtempelmeyer/tax_cloud.png" />}[https://travis-ci.org/drewtempelmeyer/tax_cloud]
+
 TaxCloud[http://www.taxcloud.com] is a free service to calculate sales tax and generate tax reports. The <tt>tax_cloud</tt> gem allows you to easily integrate with TaxCloud's API.
 
 === Getting Started
@@ -112,3 +114,4 @@ The tax code constants may require a bit of cleanup, including removing of a few
 * Fix.
 * Commit.
 * Submit pull request.
+

--- a/lib/tax_cloud/errors/missing_config_option_error.rb
+++ b/lib/tax_cloud/errors/missing_config_option_error.rb
@@ -11,7 +11,7 @@ module TaxCloud
         super(
           compose_message(
             "missing_config_option",
-            { name: name }
+            { :name => name }
           )
         )
       end

--- a/lib/tax_cloud/errors/tax_cloud_error.rb
+++ b/lib/tax_cloud/errors/tax_cloud_error.rb
@@ -38,7 +38,7 @@ module TaxCloud
       #
       # @return [ String ] A localized error message string.
       def translate(key, options)
-        ::I18n.translate("#{BASE_KEY}.#{key}", { locale: :en }.merge(options)).strip
+        ::I18n.translate("#{BASE_KEY}.#{key}", { :locale => :en }.merge(options)).strip
       end
 
       # Create the problem.

--- a/test/test_setup.rb
+++ b/test/test_setup.rb
@@ -1,5 +1,9 @@
 class TestSetup < Test::Unit::TestCase
 
+  def default_test
+    # placeholder to avoid error under Ruby 1.8.7
+  end
+
   def setup
     TaxCloud.configure do |config|
       config.api_login_id = ENV['TAXCLOUD_API_LOGIN_ID'] || 'taxcloud_api_login_id'


### PR DESCRIPTION
Added continuous integration with TravisCI. You will need to login on TravisCI with your Github account and enable CI for the tax_cloud gem.

Fixed Ruby 1.8.7 issues. What's nice about Travis is that it will catch those kinds of problems for us :)
