### PR TITLE
Added TaxCloud::Address.zip, returns a 9-digit zip code, when available.

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -3,6 +3,7 @@
 * Raise specialized configuration and SOAP errors - @dblock.
 * Added <tt>TaxCloud::Client.ping</tt> - @dblock.
 * Returning a verified <tt>TaxCloud::Address</tt> from <tt>TaxCloud::Address.verify</tt> - @dblock.
+* Added <tt>TaxCloud::Address.zip</tt> that returns a 9-digit address zip code, when available - @dblock.
 * Returning a <tt>TaxCloud::Responses::Lookup</tt> from <tt>TaxCloud::Transaction.lookup</tt> - @dblock.
 * Returning transaction state, ie. <tt>"OK"</tt> from all other TaxCloud transactions. Exceptions are raised on error.
 * Added support for tax codes and tax code groups lookup with <tt>TaxCloud::TaxCodes</tt> and <tt>TaxCloud::TaxCode::Groups</tt>.

--- a/lib/tax_cloud/address.rb
+++ b/lib/tax_cloud/address.rb
@@ -6,11 +6,18 @@ module TaxCloud
     # Verify the address via TaxCloud
     def verify
       params = to_hash.downcase_keys
-      params = params.merge({ 
-        'uspsUserID' => TaxCloud.configuration.usps_username 
+      params = params.merge({
+        'uspsUserID' => TaxCloud.configuration.usps_username
       }) if TaxCloud.configuration.usps_username
       response = TaxCloud.client.request(:verify_address, params)
       TaxCloud::Responses::VerifyAddress.parse(response)
+    end
+
+    # Compelte zip code.
+    # Returns a 9-digit Zip Code, when available.
+    def zip
+      return nil unless zip5 && zip5.length > 0
+      [ zip5, zip4 ].select { |z| z && z.length > 0 }.join("-")
     end
 
     # Convert the object to a usable hash for SOAP requests

--- a/test/test_address.rb
+++ b/test/test_address.rb
@@ -16,6 +16,16 @@ class TestAddress < TestSetup
     assert_equal nil, @address.zip4
   end
 
+  def test_zip
+    assert_equal '10001', @address.zip
+    # 9-digit zip
+    @address.zip4 = '1234'
+    assert_equal '10001-1234', @address.zip
+    # only 4-digit zip, which is invalid
+    @address.zip5 = nil
+    assert_equal nil, @address.zip
+  end
+
   def test_address_respond_to_verify
     assert_respond_to @address, :verify
   end


### PR DESCRIPTION
Special care been taken not to return a zip when only a 4-digit zip is set.
