### PR TITLE
fix: change taxcloud api endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
     @brchristian.
 *   Migrate from Travis CI to GitHub Actions -
     @rchekaluk.
+*   Update WSDL endpoint URL as recommended by TaxCloud to
+    https://api.taxcloud.com/1.0/?wsdl - @mrmarcondes.
 *   Your contribution here.
 
 

--- a/lib/tax_cloud.rb
+++ b/lib/tax_cloud.rb
@@ -29,7 +29,7 @@ I18n.load_path << File.join(File.dirname(__FILE__), 'config', 'locales', 'en.yml
 # For information on configuring and using the TaxCloud API, look at the <tt>README</tt> file.
 module TaxCloud
   # WSDL location for TaxCloud API.
-  WSDL_URL = 'https://asmx.taxcloud.com/1.0/?wsdl'
+  WSDL_URL = 'https://api.taxcloud.com/1.0/?wsdl'
 
   # TaxCloud API version.
   API_VERSION = '1.0'

--- a/lib/tax_cloud/responses/authorized.rb
+++ b/lib/tax_cloud/responses/authorized.rb
@@ -4,7 +4,7 @@ module TaxCloud #:nodoc:
   module Responses #:nodoc:
     # Response to a TaxCloud Authorized API call.
     #
-    # See https://asmx.taxcloud.com/1.0/TaxCloud.asmx?op=Authorized.
+    # See https://api.taxcloud.com/1.0/TaxCloud.asmx?op=Authorized.
     class Authorized < Generic
       response_key :authorized
     end

--- a/lib/tax_cloud/responses/authorized_with_capture.rb
+++ b/lib/tax_cloud/responses/authorized_with_capture.rb
@@ -4,7 +4,7 @@ module TaxCloud #:nodoc:
   module Responses #:nodoc:
     # Response to a TaxCloud AuthorizedWithCapture API call.
     #
-    # See https://asmx.taxcloud.com/1.0/TaxCloud.asmx?op=AuthorizedWithCapture.
+    # See https://api.taxcloud.com/1.0/TaxCloud.asmx?op=AuthorizedWithCapture.
     class AuthorizedWithCapture < Generic
       response_key :authorized_with_capture
     end

--- a/lib/tax_cloud/responses/captured.rb
+++ b/lib/tax_cloud/responses/captured.rb
@@ -4,7 +4,7 @@ module TaxCloud #:nodoc:
   module Responses #:nodoc:
     # Response to a TaxCloud Captured API call.
     #
-    # See https://asmx.taxcloud.com/1.0/TaxCloud.asmx?op=Captured.
+    # See https://api.taxcloud.com/1.0/TaxCloud.asmx?op=Captured.
     class Captured < Generic
       response_key :captured
     end

--- a/lib/tax_cloud/responses/cart_item.rb
+++ b/lib/tax_cloud/responses/cart_item.rb
@@ -6,7 +6,7 @@ module TaxCloud #:nodoc:
   module Responses #:nodoc:
     # A single item in the response to a TaxCloud Lookup API call.
     #
-    # See https://asmx.taxcloud.com/1.0/TaxCloud.asmx?op=Lookup.
+    # See https://api.taxcloud.com/1.0/TaxCloud.asmx?op=Lookup.
     class CartItem
       # The index of the cart item.
       attr_accessor :cart_item_index

--- a/lib/tax_cloud/responses/lookup.rb
+++ b/lib/tax_cloud/responses/lookup.rb
@@ -4,7 +4,7 @@ module TaxCloud #:nodoc:
   module Responses #:nodoc:
     # Response to a TaxCloud Lookup API call.
     #
-    # See https://asmx.taxcloud.com/1.0/TaxCloud.asmx?op=Lookup.
+    # See https://api.taxcloud.com/1.0/TaxCloud.asmx?op=Lookup.
     class Lookup < Base
       # Cart ID.
       attr_accessor :cart_id

--- a/lib/tax_cloud/responses/ping.rb
+++ b/lib/tax_cloud/responses/ping.rb
@@ -4,7 +4,7 @@ module TaxCloud #:nodoc:
   module Responses #:nodoc:
     # Response to a TaxCloud Ping API call.
     #
-    # See https://asmx.taxcloud.com/1.0/TaxCloud.asmx?op=Ping.
+    # See https://api.taxcloud.com/1.0/TaxCloud.asmx?op=Ping.
     class Ping < Generic
       response_key :ping
     end

--- a/lib/tax_cloud/responses/returned.rb
+++ b/lib/tax_cloud/responses/returned.rb
@@ -4,7 +4,7 @@ module TaxCloud #:nodoc:
   module Responses #:nodoc:
     # Response to a TaxCloud Returned API call.
     #
-    # See https://asmx.taxcloud.com/1.0/TaxCloud.asmx?op=Returned.
+    # See https://api.taxcloud.com/1.0/TaxCloud.asmx?op=Returned.
     class Returned < Generic
       response_key :returned
     end

--- a/lib/tax_cloud/responses/tax_code_groups.rb
+++ b/lib/tax_cloud/responses/tax_code_groups.rb
@@ -4,7 +4,7 @@ module TaxCloud #:nodoc:
   module Responses #:nodoc:
     # Response to a TaxCloud getTICGroups API call.
     #
-    # https://asmx.taxcloud.com/1.0/TaxCloud.asmx?op=GetTICGroups
+    # https://api.taxcloud.com/1.0/TaxCloud.asmx?op=GetTICGroups
     class TaxCodeGroups < Base
       response_type 'get_tic_groups_response/get_tic_groups_result/response_type'
       error_message 'get_tic_groups_response/get_tic_groups_result/messages/response_message/message'

--- a/lib/tax_cloud/responses/tax_codes.rb
+++ b/lib/tax_cloud/responses/tax_codes.rb
@@ -4,7 +4,7 @@ module TaxCloud #:nodoc:
   module Responses #:nodoc:
     # Response to a TaxCloud getTICs API call.
     #
-    # See https://asmx.taxcloud.com/1.0/TaxCloud.asmx?op=GetTICs.
+    # See https://api.taxcloud.com/1.0/TaxCloud.asmx?op=GetTICs.
     class TaxCodes < Base
       response_type 'get_ti_cs_response/get_ti_cs_result/response_type'
       error_message 'get_ti_cs_response/get_ti_cs_result/messages/response_message/message'

--- a/lib/tax_cloud/responses/tax_codes_by_group.rb
+++ b/lib/tax_cloud/responses/tax_codes_by_group.rb
@@ -4,7 +4,7 @@ module TaxCloud #:nodoc:
   module Responses #:nodoc:
     # Response to a TaxCloud getTICsByGroup API call.
     #
-    # See https://asmx.taxcloud.com/1.0/TaxCloud.asmx?op=GetTICsByGroup.
+    # See https://api.taxcloud.com/1.0/TaxCloud.asmx?op=GetTICsByGroup.
     class TaxCodesByGroup < Base
       response_type 'get_ti_cs_by_group_response/get_ti_cs_by_group_result/response_type'
       error_message 'get_ti_cs_by_group_response/get_ti_cs_by_group_result/messages/response_message/message'

--- a/lib/tax_cloud/responses/verify_address.rb
+++ b/lib/tax_cloud/responses/verify_address.rb
@@ -4,7 +4,7 @@ module TaxCloud #:nodoc:
   module Responses #:nodoc:
     # Response to a TaxCloud VerifyAddress API call.
     #
-    # See https://asmx.taxcloud.com/1.0/TaxCloud.asmx?op=VerifyAddress.
+    # See https://api.taxcloud.com/1.0/TaxCloud.asmx?op=VerifyAddress.
     class VerifyAddress < Base
       error_number 'verify_address_response/verify_address_result/err_number'
       error_message 'verify_address_response/verify_address_result/err_description'

--- a/test/cassettes/authorized.yml
+++ b/test/cassettes/authorized.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://asmx.taxcloud.com/1.0/?wsdl
+    uri: https://api.taxcloud.com/1.0/?wsdl
     body:
       encoding: US-ASCII
       string: ''
@@ -719,17 +719,17 @@ http_interactions:
         part=\"Body\" />\r\n      </wsdl:output>\r\n    </wsdl:operation>\r\n  </wsdl:binding>\r\n
         \ <wsdl:service name=\"TaxCloud\">\r\n    <wsdl:documentation xmlns:wsdl=\"http://schemas.xmlsoap.org/wsdl/\">TaxCloud
         Web Service</wsdl:documentation>\r\n    <wsdl:port name=\"TaxCloudSoap\" binding=\"tns:TaxCloudSoap\">\r\n
-        \     <soap:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <soap:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n    <wsdl:port name=\"TaxCloudSoap12\" binding=\"tns:TaxCloudSoap12\">\r\n
-        \     <soap12:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <soap12:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n    <wsdl:port name=\"TaxCloudHttpPost\" binding=\"tns:TaxCloudHttpPost\">\r\n
-        \     <http:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <http:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n  </wsdl:service>\r\n</wsdl:definitions>"
     http_version:
   recorded_at: Thu, 09 Jan 2014 16:03:39 GMT
 - request:
     method: post
-    uri: https://asmx.taxcloud.com/1.0/TaxCloud.asmx
+    uri: https://api.taxcloud.com/1.0/TaxCloud.asmx
     body:
       encoding: US-ASCII
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
@@ -779,7 +779,7 @@ http_interactions:
   recorded_at: Fri, 01 Mar 2013 22:58:17 GMT
 - request:
     method: post
-    uri: https://asmx.taxcloud.com/1.0/TaxCloud.asmx
+    uri: https://api.taxcloud.com/1.0/TaxCloud.asmx
     body:
       encoding: US-ASCII
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"

--- a/test/cassettes/authorized_with_capture.yml
+++ b/test/cassettes/authorized_with_capture.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://asmx.taxcloud.com/1.0/?wsdl
+    uri: https://api.taxcloud.com/1.0/?wsdl
     body:
       encoding: US-ASCII
       string: ''
@@ -719,17 +719,17 @@ http_interactions:
         part=\"Body\" />\r\n      </wsdl:output>\r\n    </wsdl:operation>\r\n  </wsdl:binding>\r\n
         \ <wsdl:service name=\"TaxCloud\">\r\n    <wsdl:documentation xmlns:wsdl=\"http://schemas.xmlsoap.org/wsdl/\">TaxCloud
         Web Service</wsdl:documentation>\r\n    <wsdl:port name=\"TaxCloudSoap\" binding=\"tns:TaxCloudSoap\">\r\n
-        \     <soap:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <soap:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n    <wsdl:port name=\"TaxCloudSoap12\" binding=\"tns:TaxCloudSoap12\">\r\n
-        \     <soap12:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <soap12:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n    <wsdl:port name=\"TaxCloudHttpPost\" binding=\"tns:TaxCloudHttpPost\">\r\n
-        \     <http:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <http:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n  </wsdl:service>\r\n</wsdl:definitions>"
     http_version:
   recorded_at: Thu, 09 Jan 2014 16:03:39 GMT
 - request:
     method: post
-    uri: https://asmx.taxcloud.com/1.0/TaxCloud.asmx
+    uri: https://api.taxcloud.com/1.0/TaxCloud.asmx
     body:
       encoding: US-ASCII
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
@@ -779,7 +779,7 @@ http_interactions:
   recorded_at: Fri, 01 Mar 2013 22:58:18 GMT
 - request:
     method: post
-    uri: https://asmx.taxcloud.com/1.0/TaxCloud.asmx
+    uri: https://api.taxcloud.com/1.0/TaxCloud.asmx
     body:
       encoding: US-ASCII
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"

--- a/test/cassettes/authorized_with_localized_time.yml
+++ b/test/cassettes/authorized_with_localized_time.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://asmx.taxcloud.com/1.0/?wsdl
+    uri: https://api.taxcloud.com/1.0/?wsdl
     body:
       encoding: US-ASCII
       string: ''
@@ -719,17 +719,17 @@ http_interactions:
         part=\"Body\" />\r\n      </wsdl:output>\r\n    </wsdl:operation>\r\n  </wsdl:binding>\r\n
         \ <wsdl:service name=\"TaxCloud\">\r\n    <wsdl:documentation xmlns:wsdl=\"http://schemas.xmlsoap.org/wsdl/\">TaxCloud
         Web Service</wsdl:documentation>\r\n    <wsdl:port name=\"TaxCloudSoap\" binding=\"tns:TaxCloudSoap\">\r\n
-        \     <soap:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <soap:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n    <wsdl:port name=\"TaxCloudSoap12\" binding=\"tns:TaxCloudSoap12\">\r\n
-        \     <soap12:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <soap12:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n    <wsdl:port name=\"TaxCloudHttpPost\" binding=\"tns:TaxCloudHttpPost\">\r\n
-        \     <http:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <http:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n  </wsdl:service>\r\n</wsdl:definitions>"
     http_version:
   recorded_at: Thu, 09 Jan 2014 16:03:39 GMT
 - request:
     method: post
-    uri: https://asmx.taxcloud.com/1.0/TaxCloud.asmx
+    uri: https://api.taxcloud.com/1.0/TaxCloud.asmx
     body:
       encoding: US-ASCII
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
@@ -779,7 +779,7 @@ http_interactions:
   recorded_at: Sat, 02 Mar 2013 04:12:51 GMT
 - request:
     method: post
-    uri: https://asmx.taxcloud.com/1.0/TaxCloud.asmx
+    uri: https://api.taxcloud.com/1.0/TaxCloud.asmx
     body:
       encoding: US-ASCII
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"

--- a/test/cassettes/captured.yml
+++ b/test/cassettes/captured.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://asmx.taxcloud.com/1.0/?wsdl
+    uri: https://api.taxcloud.com/1.0/?wsdl
     body:
       encoding: US-ASCII
       string: ''
@@ -719,17 +719,17 @@ http_interactions:
         part=\"Body\" />\r\n      </wsdl:output>\r\n    </wsdl:operation>\r\n  </wsdl:binding>\r\n
         \ <wsdl:service name=\"TaxCloud\">\r\n    <wsdl:documentation xmlns:wsdl=\"http://schemas.xmlsoap.org/wsdl/\">TaxCloud
         Web Service</wsdl:documentation>\r\n    <wsdl:port name=\"TaxCloudSoap\" binding=\"tns:TaxCloudSoap\">\r\n
-        \     <soap:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <soap:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n    <wsdl:port name=\"TaxCloudSoap12\" binding=\"tns:TaxCloudSoap12\">\r\n
-        \     <soap12:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <soap12:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n    <wsdl:port name=\"TaxCloudHttpPost\" binding=\"tns:TaxCloudHttpPost\">\r\n
-        \     <http:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <http:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n  </wsdl:service>\r\n</wsdl:definitions>"
     http_version:
   recorded_at: Thu, 09 Jan 2014 16:03:39 GMT
 - request:
     method: post
-    uri: https://asmx.taxcloud.com/1.0/TaxCloud.asmx
+    uri: https://api.taxcloud.com/1.0/TaxCloud.asmx
     body:
       encoding: US-ASCII
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
@@ -779,7 +779,7 @@ http_interactions:
   recorded_at: Fri, 01 Mar 2013 22:58:19 GMT
 - request:
     method: post
-    uri: https://asmx.taxcloud.com/1.0/TaxCloud.asmx
+    uri: https://api.taxcloud.com/1.0/TaxCloud.asmx
     body:
       encoding: US-ASCII
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
@@ -825,7 +825,7 @@ http_interactions:
   recorded_at: Fri, 01 Mar 2013 22:58:19 GMT
 - request:
     method: post
-    uri: https://asmx.taxcloud.com/1.0/TaxCloud.asmx
+    uri: https://api.taxcloud.com/1.0/TaxCloud.asmx
     body:
       encoding: US-ASCII
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"

--- a/test/cassettes/get_tic_groups.yml
+++ b/test/cassettes/get_tic_groups.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://asmx.taxcloud.com/1.0/?wsdl
+    uri: https://api.taxcloud.com/1.0/?wsdl
     body:
       encoding: US-ASCII
       string: ''
@@ -719,17 +719,17 @@ http_interactions:
         part=\"Body\" />\r\n      </wsdl:output>\r\n    </wsdl:operation>\r\n  </wsdl:binding>\r\n
         \ <wsdl:service name=\"TaxCloud\">\r\n    <wsdl:documentation xmlns:wsdl=\"http://schemas.xmlsoap.org/wsdl/\">TaxCloud
         Web Service</wsdl:documentation>\r\n    <wsdl:port name=\"TaxCloudSoap\" binding=\"tns:TaxCloudSoap\">\r\n
-        \     <soap:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <soap:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n    <wsdl:port name=\"TaxCloudSoap12\" binding=\"tns:TaxCloudSoap12\">\r\n
-        \     <soap12:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <soap12:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n    <wsdl:port name=\"TaxCloudHttpPost\" binding=\"tns:TaxCloudHttpPost\">\r\n
-        \     <http:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <http:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n  </wsdl:service>\r\n</wsdl:definitions>"
     http_version:
   recorded_at: Thu, 09 Jan 2014 16:03:39 GMT
 - request:
     method: post
-    uri: https://asmx.taxcloud.com/1.0/TaxCloud.asmx
+    uri: https://api.taxcloud.com/1.0/TaxCloud.asmx
     body:
       encoding: US-ASCII
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"

--- a/test/cassettes/get_tics.yml
+++ b/test/cassettes/get_tics.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://asmx.taxcloud.com/1.0/?wsdl
+    uri: https://api.taxcloud.com/1.0/?wsdl
     body:
       encoding: US-ASCII
       string: ''
@@ -719,17 +719,17 @@ http_interactions:
         part=\"Body\" />\r\n      </wsdl:output>\r\n    </wsdl:operation>\r\n  </wsdl:binding>\r\n
         \ <wsdl:service name=\"TaxCloud\">\r\n    <wsdl:documentation xmlns:wsdl=\"http://schemas.xmlsoap.org/wsdl/\">TaxCloud
         Web Service</wsdl:documentation>\r\n    <wsdl:port name=\"TaxCloudSoap\" binding=\"tns:TaxCloudSoap\">\r\n
-        \     <soap:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <soap:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n    <wsdl:port name=\"TaxCloudSoap12\" binding=\"tns:TaxCloudSoap12\">\r\n
-        \     <soap12:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <soap12:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n    <wsdl:port name=\"TaxCloudHttpPost\" binding=\"tns:TaxCloudHttpPost\">\r\n
-        \     <http:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <http:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n  </wsdl:service>\r\n</wsdl:definitions>"
     http_version:
   recorded_at: Thu, 09 Jan 2014 16:03:39 GMT
 - request:
     method: post
-    uri: https://asmx.taxcloud.com/1.0/TaxCloud.asmx
+    uri: https://api.taxcloud.com/1.0/TaxCloud.asmx
     body:
       encoding: US-ASCII
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"

--- a/test/cassettes/get_tics_by_group.yml
+++ b/test/cassettes/get_tics_by_group.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://asmx.taxcloud.com/1.0/?wsdl
+    uri: https://api.taxcloud.com/1.0/?wsdl
     body:
       encoding: US-ASCII
       string: ''
@@ -719,17 +719,17 @@ http_interactions:
         part=\"Body\" />\r\n      </wsdl:output>\r\n    </wsdl:operation>\r\n  </wsdl:binding>\r\n
         \ <wsdl:service name=\"TaxCloud\">\r\n    <wsdl:documentation xmlns:wsdl=\"http://schemas.xmlsoap.org/wsdl/\">TaxCloud
         Web Service</wsdl:documentation>\r\n    <wsdl:port name=\"TaxCloudSoap\" binding=\"tns:TaxCloudSoap\">\r\n
-        \     <soap:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <soap:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n    <wsdl:port name=\"TaxCloudSoap12\" binding=\"tns:TaxCloudSoap12\">\r\n
-        \     <soap12:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <soap12:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n    <wsdl:port name=\"TaxCloudHttpPost\" binding=\"tns:TaxCloudHttpPost\">\r\n
-        \     <http:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <http:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n  </wsdl:service>\r\n</wsdl:definitions>"
     http_version:
   recorded_at: Thu, 09 Jan 2014 16:03:39 GMT
 - request:
     method: post
-    uri: https://asmx.taxcloud.com/1.0/TaxCloud.asmx
+    uri: https://api.taxcloud.com/1.0/TaxCloud.asmx
     body:
       encoding: US-ASCII
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"

--- a/test/cassettes/invalid_soap_call.yml
+++ b/test/cassettes/invalid_soap_call.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://asmx.taxcloud.com/1.0/?wsdl
+    uri: https://api.taxcloud.com/1.0/?wsdl
     body:
       encoding: US-ASCII
       string: ''
@@ -719,17 +719,17 @@ http_interactions:
         part=\"Body\" />\r\n      </wsdl:output>\r\n    </wsdl:operation>\r\n  </wsdl:binding>\r\n
         \ <wsdl:service name=\"TaxCloud\">\r\n    <wsdl:documentation xmlns:wsdl=\"http://schemas.xmlsoap.org/wsdl/\">TaxCloud
         Web Service</wsdl:documentation>\r\n    <wsdl:port name=\"TaxCloudSoap\" binding=\"tns:TaxCloudSoap\">\r\n
-        \     <soap:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <soap:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n    <wsdl:port name=\"TaxCloudSoap12\" binding=\"tns:TaxCloudSoap12\">\r\n
-        \     <soap12:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <soap12:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n    <wsdl:port name=\"TaxCloudHttpPost\" binding=\"tns:TaxCloudHttpPost\">\r\n
-        \     <http:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <http:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n  </wsdl:service>\r\n</wsdl:definitions>"
     http_version:
   recorded_at: Thu, 09 Jan 2014 16:03:39 GMT
 - request:
     method: post
-    uri: https://asmx.taxcloud.com/1.0/TaxCloud.asmx
+    uri: https://api.taxcloud.com/1.0/TaxCloud.asmx
     body:
       encoding: US-ASCII
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"

--- a/test/cassettes/lookup.yml
+++ b/test/cassettes/lookup.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://asmx.taxcloud.com/1.0/?wsdl
+    uri: https://api.taxcloud.com/1.0/?wsdl
     body:
       encoding: US-ASCII
       string: ''
@@ -719,17 +719,17 @@ http_interactions:
         part=\"Body\" />\r\n      </wsdl:output>\r\n    </wsdl:operation>\r\n  </wsdl:binding>\r\n
         \ <wsdl:service name=\"TaxCloud\">\r\n    <wsdl:documentation xmlns:wsdl=\"http://schemas.xmlsoap.org/wsdl/\">TaxCloud
         Web Service</wsdl:documentation>\r\n    <wsdl:port name=\"TaxCloudSoap\" binding=\"tns:TaxCloudSoap\">\r\n
-        \     <soap:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <soap:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n    <wsdl:port name=\"TaxCloudSoap12\" binding=\"tns:TaxCloudSoap12\">\r\n
-        \     <soap12:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <soap12:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n    <wsdl:port name=\"TaxCloudHttpPost\" binding=\"tns:TaxCloudHttpPost\">\r\n
-        \     <http:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <http:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n  </wsdl:service>\r\n</wsdl:definitions>"
     http_version:
   recorded_at: Thu, 09 Jan 2014 16:03:39 GMT
 - request:
     method: post
-    uri: https://asmx.taxcloud.com/1.0/TaxCloud.asmx
+    uri: https://api.taxcloud.com/1.0/TaxCloud.asmx
     body:
       encoding: US-ASCII
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"

--- a/test/cassettes/lookup_ny.yml
+++ b/test/cassettes/lookup_ny.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://asmx.taxcloud.com/1.0/?wsdl
+    uri: https://api.taxcloud.com/1.0/?wsdl
     body:
       encoding: US-ASCII
       string: ''
@@ -719,17 +719,17 @@ http_interactions:
         part=\"Body\" />\r\n      </wsdl:output>\r\n    </wsdl:operation>\r\n  </wsdl:binding>\r\n
         \ <wsdl:service name=\"TaxCloud\">\r\n    <wsdl:documentation xmlns:wsdl=\"http://schemas.xmlsoap.org/wsdl/\">TaxCloud
         Web Service</wsdl:documentation>\r\n    <wsdl:port name=\"TaxCloudSoap\" binding=\"tns:TaxCloudSoap\">\r\n
-        \     <soap:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <soap:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n    <wsdl:port name=\"TaxCloudSoap12\" binding=\"tns:TaxCloudSoap12\">\r\n
-        \     <soap12:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <soap12:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n    <wsdl:port name=\"TaxCloudHttpPost\" binding=\"tns:TaxCloudHttpPost\">\r\n
-        \     <http:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <http:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n  </wsdl:service>\r\n</wsdl:definitions>"
     http_version:
   recorded_at: Thu, 09 Jan 2014 16:03:39 GMT
 - request:
     method: post
-    uri: https://asmx.taxcloud.com/1.0/TaxCloud.asmx
+    uri: https://api.taxcloud.com/1.0/TaxCloud.asmx
     body:
       encoding: US-ASCII
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"

--- a/test/cassettes/ping.yml
+++ b/test/cassettes/ping.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://asmx.taxcloud.com/1.0/?wsdl
+    uri: https://api.taxcloud.com/1.0/?wsdl
     body:
       encoding: US-ASCII
       string: ''
@@ -719,17 +719,17 @@ http_interactions:
         part=\"Body\" />\r\n      </wsdl:output>\r\n    </wsdl:operation>\r\n  </wsdl:binding>\r\n
         \ <wsdl:service name=\"TaxCloud\">\r\n    <wsdl:documentation xmlns:wsdl=\"http://schemas.xmlsoap.org/wsdl/\">TaxCloud
         Web Service</wsdl:documentation>\r\n    <wsdl:port name=\"TaxCloudSoap\" binding=\"tns:TaxCloudSoap\">\r\n
-        \     <soap:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <soap:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n    <wsdl:port name=\"TaxCloudSoap12\" binding=\"tns:TaxCloudSoap12\">\r\n
-        \     <soap12:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <soap12:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n    <wsdl:port name=\"TaxCloudHttpPost\" binding=\"tns:TaxCloudHttpPost\">\r\n
-        \     <http:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <http:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n  </wsdl:service>\r\n</wsdl:definitions>"
     http_version:
   recorded_at: Thu, 09 Jan 2014 16:03:39 GMT
 - request:
     method: post
-    uri: https://asmx.taxcloud.com/1.0/TaxCloud.asmx
+    uri: https://api.taxcloud.com/1.0/TaxCloud.asmx
     body:
       encoding: US-ASCII
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"

--- a/test/cassettes/ping_with_invalid_credentials.yml
+++ b/test/cassettes/ping_with_invalid_credentials.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://asmx.taxcloud.com/1.0/?wsdl
+    uri: https://api.taxcloud.com/1.0/?wsdl
     body:
       encoding: US-ASCII
       string: ''
@@ -719,17 +719,17 @@ http_interactions:
         part=\"Body\" />\r\n      </wsdl:output>\r\n    </wsdl:operation>\r\n  </wsdl:binding>\r\n
         \ <wsdl:service name=\"TaxCloud\">\r\n    <wsdl:documentation xmlns:wsdl=\"http://schemas.xmlsoap.org/wsdl/\">TaxCloud
         Web Service</wsdl:documentation>\r\n    <wsdl:port name=\"TaxCloudSoap\" binding=\"tns:TaxCloudSoap\">\r\n
-        \     <soap:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <soap:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n    <wsdl:port name=\"TaxCloudSoap12\" binding=\"tns:TaxCloudSoap12\">\r\n
-        \     <soap12:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <soap12:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n    <wsdl:port name=\"TaxCloudHttpPost\" binding=\"tns:TaxCloudHttpPost\">\r\n
-        \     <http:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <http:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n  </wsdl:service>\r\n</wsdl:definitions>"
     http_version:
   recorded_at: Thu, 09 Jan 2014 16:03:39 GMT
 - request:
     method: post
-    uri: https://asmx.taxcloud.com/1.0/TaxCloud.asmx
+    uri: https://api.taxcloud.com/1.0/TaxCloud.asmx
     body:
       encoding: US-ASCII
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"

--- a/test/cassettes/ping_with_invalid_response.yml
+++ b/test/cassettes/ping_with_invalid_response.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://asmx.taxcloud.com/1.0/?wsdl
+    uri: https://api.taxcloud.com/1.0/?wsdl
     body:
       encoding: US-ASCII
       string: ''
@@ -719,17 +719,17 @@ http_interactions:
         part=\"Body\" />\r\n      </wsdl:output>\r\n    </wsdl:operation>\r\n  </wsdl:binding>\r\n
         \ <wsdl:service name=\"TaxCloud\">\r\n    <wsdl:documentation xmlns:wsdl=\"http://schemas.xmlsoap.org/wsdl/\">TaxCloud
         Web Service</wsdl:documentation>\r\n    <wsdl:port name=\"TaxCloudSoap\" binding=\"tns:TaxCloudSoap\">\r\n
-        \     <soap:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <soap:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n    <wsdl:port name=\"TaxCloudSoap12\" binding=\"tns:TaxCloudSoap12\">\r\n
-        \     <soap12:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <soap12:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n    <wsdl:port name=\"TaxCloudHttpPost\" binding=\"tns:TaxCloudHttpPost\">\r\n
-        \     <http:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <http:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n  </wsdl:service>\r\n</wsdl:definitions>"
     http_version:
   recorded_at: Thu, 09 Jan 2014 16:03:39 GMT
 - request:
     method: post
-    uri: https://asmx.taxcloud.com/1.0/TaxCloud.asmx
+    uri: https://api.taxcloud.com/1.0/TaxCloud.asmx
     body:
       encoding: US-ASCII
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"

--- a/test/cassettes/returned.yml
+++ b/test/cassettes/returned.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://asmx.taxcloud.com/1.0/?wsdl
+    uri: https://api.taxcloud.com/1.0/?wsdl
     body:
       encoding: US-ASCII
       string: ''
@@ -719,17 +719,17 @@ http_interactions:
         part=\"Body\" />\r\n      </wsdl:output>\r\n    </wsdl:operation>\r\n  </wsdl:binding>\r\n
         \ <wsdl:service name=\"TaxCloud\">\r\n    <wsdl:documentation xmlns:wsdl=\"http://schemas.xmlsoap.org/wsdl/\">TaxCloud
         Web Service</wsdl:documentation>\r\n    <wsdl:port name=\"TaxCloudSoap\" binding=\"tns:TaxCloudSoap\">\r\n
-        \     <soap:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <soap:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n    <wsdl:port name=\"TaxCloudSoap12\" binding=\"tns:TaxCloudSoap12\">\r\n
-        \     <soap12:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <soap12:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n    <wsdl:port name=\"TaxCloudHttpPost\" binding=\"tns:TaxCloudHttpPost\">\r\n
-        \     <http:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <http:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n  </wsdl:service>\r\n</wsdl:definitions>"
     http_version:
   recorded_at: Thu, 09 Jan 2014 16:03:39 GMT
 - request:
     method: post
-    uri: https://asmx.taxcloud.com/1.0/TaxCloud.asmx
+    uri: https://api.taxcloud.com/1.0/TaxCloud.asmx
     body:
       encoding: US-ASCII
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
@@ -779,7 +779,7 @@ http_interactions:
   recorded_at: Fri, 01 Mar 2013 22:58:21 GMT
 - request:
     method: post
-    uri: https://asmx.taxcloud.com/1.0/TaxCloud.asmx
+    uri: https://api.taxcloud.com/1.0/TaxCloud.asmx
     body:
       encoding: US-ASCII
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
@@ -825,7 +825,7 @@ http_interactions:
   recorded_at: Fri, 01 Mar 2013 22:58:21 GMT
 - request:
     method: post
-    uri: https://asmx.taxcloud.com/1.0/TaxCloud.asmx
+    uri: https://api.taxcloud.com/1.0/TaxCloud.asmx
     body:
       encoding: US-ASCII
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"

--- a/test/cassettes/verify_bad_address.yml
+++ b/test/cassettes/verify_bad_address.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://asmx.taxcloud.com/1.0/?wsdl
+    uri: https://api.taxcloud.com/1.0/?wsdl
     body:
       encoding: US-ASCII
       string: ''
@@ -719,17 +719,17 @@ http_interactions:
         part=\"Body\" />\r\n      </wsdl:output>\r\n    </wsdl:operation>\r\n  </wsdl:binding>\r\n
         \ <wsdl:service name=\"TaxCloud\">\r\n    <wsdl:documentation xmlns:wsdl=\"http://schemas.xmlsoap.org/wsdl/\">TaxCloud
         Web Service</wsdl:documentation>\r\n    <wsdl:port name=\"TaxCloudSoap\" binding=\"tns:TaxCloudSoap\">\r\n
-        \     <soap:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <soap:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n    <wsdl:port name=\"TaxCloudSoap12\" binding=\"tns:TaxCloudSoap12\">\r\n
-        \     <soap12:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <soap12:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n    <wsdl:port name=\"TaxCloudHttpPost\" binding=\"tns:TaxCloudHttpPost\">\r\n
-        \     <http:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <http:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n  </wsdl:service>\r\n</wsdl:definitions>"
     http_version:
   recorded_at: Thu, 09 Jan 2014 16:03:39 GMT
 - request:
     method: post
-    uri: https://asmx.taxcloud.com/1.0/TaxCloud.asmx
+    uri: https://api.taxcloud.com/1.0/TaxCloud.asmx
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"

--- a/test/cassettes/verify_good_address.yml
+++ b/test/cassettes/verify_good_address.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://asmx.taxcloud.com/1.0/?wsdl
+    uri: https://api.taxcloud.com/1.0/?wsdl
     body:
       encoding: US-ASCII
       string: ''
@@ -719,17 +719,17 @@ http_interactions:
         part=\"Body\" />\r\n      </wsdl:output>\r\n    </wsdl:operation>\r\n  </wsdl:binding>\r\n
         \ <wsdl:service name=\"TaxCloud\">\r\n    <wsdl:documentation xmlns:wsdl=\"http://schemas.xmlsoap.org/wsdl/\">TaxCloud
         Web Service</wsdl:documentation>\r\n    <wsdl:port name=\"TaxCloudSoap\" binding=\"tns:TaxCloudSoap\">\r\n
-        \     <soap:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <soap:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n    <wsdl:port name=\"TaxCloudSoap12\" binding=\"tns:TaxCloudSoap12\">\r\n
-        \     <soap12:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <soap12:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n    <wsdl:port name=\"TaxCloudHttpPost\" binding=\"tns:TaxCloudHttpPost\">\r\n
-        \     <http:address location=\"https://asmx.taxcloud.com/1.0/TaxCloud.asmx\"
+        \     <http:address location=\"https://api.taxcloud.com/1.0/TaxCloud.asmx\"
         />\r\n    </wsdl:port>\r\n  </wsdl:service>\r\n</wsdl:definitions>"
     http_version:
   recorded_at: Thu, 09 Jan 2014 16:03:39 GMT
 - request:
     method: post
-    uri: https://asmx.taxcloud.com/1.0/TaxCloud.asmx
+    uri: https://api.taxcloud.com/1.0/TaxCloud.asmx
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"


### PR DESCRIPTION
Two weeks ago, the gem stopped working. We're receiving a `Connection reset by peer - SSL_connect` when we try to fetch taxcloud services.

I've opened a ticket with them, and they said:
>The issue here is the [asmx.taxcloud.com](http://asmx.taxcloud.com/) domain name. Please update to [api.taxcloud.com](http://api.taxcloud.com/) and I believe api connections will resolve correctly.

This PR changes the base address to the one suggested by their support team.
I didn't update the tests, I wasn't able to run them locally. Some of them are broken, and the cassettes are not been updated for 3 years.
